### PR TITLE
Fix: Show failed downloads in download panel (Fixes #343)

### DIFF
--- a/packages/frontend/src/components/common/DownloadFileButton/DownloadFileButton.tsx
+++ b/packages/frontend/src/components/common/DownloadFileButton/DownloadFileButton.tsx
@@ -91,7 +91,19 @@ export default function DownloadFileButton({
     } catch (error) {
       console.error('Download error:', error);
       
-      // More specific error handling
+      // Update download status to 'failed' for all selected files
+      const failedDownloadsUpdate = selectedFileInfo.map(fileInfo => ({
+        filename: fileInfo.file_name,
+        fileType: fileInfo.kind || 'Unknown',
+        progress: fileInfo.progress || 0, // Keep existing progress if available
+        status: 'failed' as const,
+        totalSize: fileInfo.file_size || 0,
+        downloadedSize: fileInfo.downloadedSize || 0, // Keep existing downloaded size
+        timeRemaining: undefined
+      }));
+      addDownloadsInfo(failedDownloadsUpdate); // Update the core download info
+
+      // More specific error handling for alerts
       if (error instanceof Error) {
         if (error.message.includes('timed out')) {
           showAlert('Download timed out', ['The download request timed out. Please try again.'], 'error');


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Fixes the download status tracking by updating failed downloads in the core download tracking system when errors occur during download initiation.

- Added code in `DownloadFileButton.tsx` to update download status to 'failed' when errors occur during download initiation.
- Implemented proper error state propagation to ensure failed downloads appear in the 'Failed' tab of the download panel.
- Preserved existing download progress and size information when marking downloads as failed.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

This PR fixes issue #343 by ensuring that the download status is updated to 'failed' in the core download tracking when an error occurs during download initiation. This allows the `DownloadProgressButton` component to correctly display failed downloads under the 'Failed' tab.