### PR TITLE
Feat: Implement download cancellation (Fixes #376)

### DIFF
--- a/packages/core/src/device/add_downloads_info.ts
+++ b/packages/core/src/device/add_downloads_info.ts
@@ -15,6 +15,9 @@ export interface DownloadInfo {
   totalSize: number;
   downloadedSize: number;
   timeRemaining?: number;
+  // Add fields needed for cancellation
+  sending_device_id?: string;
+  transfer_room?: string;
 }
 
 // Store for active downloads

--- a/packages/core/src/files/downloadFile.ts
+++ b/packages/core/src/files/downloadFile.ts
@@ -183,6 +183,40 @@ export function downloadFile(username: string, files: string[], devices: string[
             resolve('success');
           }
 
+          // Add handling for download_cancelled message type
+          if (data.type === 'download_cancelled' || data.message_type === 'download_cancelled') {
+            console.log('Download cancelled by sender or backend');
+            // Update progress to skipped
+            addDownloadsInfo([{
+              filename: files[0],
+              fileType: fileInfo[0]?.kind || 'Unknown',
+              progress: 0,
+              status: 'skipped',
+              totalSize: fileInfo[0]?.file_size || 0,
+              downloadedSize: 0,
+            }]);
+            cleanup();
+            resolve('skipped'); // Resolve with 'skipped' status instead of rejecting
+            return;
+          }
+
+          // Also handle leave_transfer_room as it may indicate a cancelled download
+          if (data.type === 'leave_transfer_room' || data.type === 'left_transfer_room') {
+            console.log('Transfer room left - marking download as skipped');
+            // Update progress to skipped if we're still downloading
+            addDownloadsInfo([{
+              filename: files[0],
+              fileType: fileInfo[0]?.kind || 'Unknown',
+              progress: 0,
+              status: 'skipped',
+              totalSize: fileInfo[0]?.file_size || 0,
+              downloadedSize: 0,
+            }]);
+            cleanup();
+            resolve('skipped');
+            return;
+          }
+
           if (['File not found', 'Device offline', 'Permission denied', 'Transfer failed', 'file_transfer_error'].includes(data.message_type || data.message)) {
             console.error('Download error message received:', data);
             // Update progress to failed for remote downloads too

--- a/packages/core/src/files/downloadFile.ts
+++ b/packages/core/src/files/downloadFile.ts
@@ -185,7 +185,6 @@ export function downloadFile(username: string, files: string[], devices: string[
 
           // Add handling for download_cancelled message type
           if (data.type === 'download_cancelled' || data.message_type === 'download_cancelled') {
-            console.log('Download cancelled by sender or backend');
             // Update progress to skipped
             addDownloadsInfo([{
               filename: files[0],
@@ -202,7 +201,6 @@ export function downloadFile(username: string, files: string[], devices: string[
 
           // Also handle leave_transfer_room as it may indicate a cancelled download
           if (data.type === 'leave_transfer_room' || data.type === 'left_transfer_room') {
-            console.log('Transfer room left - marking download as skipped');
             // Update progress to skipped if we're still downloading
             addDownloadsInfo([{
               filename: files[0],

--- a/packages/core/src/files/index.ts
+++ b/packages/core/src/files/index.ts
@@ -9,3 +9,4 @@ export * from './addDeviceIdtoFileSyncFiles';
 export * from './shareFile';
 export * from './makeFilePublic';
 export * from './makeFilePrivate';
+export { cancel_download_request } from '../websocket/files/file_transfer';

--- a/packages/core/src/files/index.ts
+++ b/packages/core/src/files/index.ts
@@ -1,3 +1,5 @@
+import { cancel_download_request as cancelDownloadRequestInternal } from '../websocket/files/file_transfer';
+
 export * from './addFiles';
 export * from './removeFiles';
 export * from './searchFile';
@@ -9,4 +11,5 @@ export * from './addDeviceIdtoFileSyncFiles';
 export * from './shareFile';
 export * from './makeFilePublic';
 export * from './makeFilePrivate';
-export { cancel_download_request } from '../websocket/files/file_transfer';
+
+export const cancel_download_request = cancelDownloadRequestInternal;

--- a/packages/core/src/websocket/createWebsocketConnection.ts
+++ b/packages/core/src/websocket/createWebsocketConnection.ts
@@ -178,6 +178,8 @@ export async function createWebSocketConnection(
       
       socket.onmessage = async function (event: MessageEvent) {
         try {
+
+          console.log('[WebSocket] Received message:', event.data);
           // Handle binary data (file chunks)
           if (event.data instanceof ArrayBuffer || event.data instanceof Blob) {
             // Pass to file transfer handler

--- a/packages/core/src/websocket/files/file_receiver.ts
+++ b/packages/core/src/websocket/files/file_receiver.ts
@@ -44,7 +44,6 @@ class FileReceiver {
     this.fileInfo = fileInfo;
     this.currentTransferRoom = transfer_room;
     const savePath = path.join(this.downloadPath, fileInfo.file_name);
-    console.log(`[FileReceiver] Starting transfer for room ${transfer_room}, file: ${fileInfo.file_name}`);
 
     try {
       // Create write stream
@@ -98,7 +97,6 @@ class FileReceiver {
     if (!this.fileStream || !this.fileInfo) {
       throw new Error('No active file transfer');
     }
-    console.log(`[FileReceiver] Completing transfer for room ${this.currentTransferRoom}`);
 
     // Store non-null variables locally
     const fileStream = this.fileStream;
@@ -129,11 +127,10 @@ class FileReceiver {
     }
   }
 
-  public stopCurrentTransfer(reason: string = 'stopped externally'): void {
+  public stopCurrentTransfer(): void {
     if (!this.fileInfo) {
       return;
     }
-    console.log(`[FileReceiver] Stopping transfer for room ${this.currentTransferRoom}. Reason: ${reason}`);
     this.cleanup();
   }
 
@@ -149,7 +146,6 @@ class FileReceiver {
     this.fileInfo = null;
     this.receivedBytes = 0;
     this.currentTransferRoom = null;
-    console.log('[FileReceiver] Cleaned up resources.');
   }
 }
 

--- a/packages/core/src/websocket/files/file_sender.ts
+++ b/packages/core/src/websocket/files/file_sender.ts
@@ -9,6 +9,21 @@ interface FileRequestData {
 
 const CHUNK_SIZE = 1024 * 64; // 64KB chunks
 
+// Map to track active sending operations and allow cancellation
+const activeSenders = new Map<string, { shouldCancel: boolean, stream: fs.ReadStream }>();
+
+// Function to signal a sender to cancel
+export function cancelFileSend(transfer_room: string): void {
+  const senderInfo = activeSenders.get(transfer_room);
+  if (senderInfo) {
+    console.log(`[FileSender] Received cancel signal for room: ${transfer_room}`);
+    senderInfo.shouldCancel = true;
+    // The stream will be destroyed and cleaned up in the sending loop
+  } else {
+    console.warn(`[FileSender] Received cancel signal for unknown/inactive room: ${transfer_room}`);
+  }
+}
+
 export async function handleFileRequest(
   data: FileRequestData,
   socket: WebSocket,
@@ -16,6 +31,20 @@ export async function handleFileRequest(
   setTasks: (tasks: any[]) => void,
 ): Promise<void> {
   const { file_name, file_path, requesting_device_id, transfer_room } = data;
+
+  if (!transfer_room) {
+    console.error('❌ [FileSender] Transfer room missing in file request data:', data);
+    // Optionally send an error back to the requester or handle appropriately
+    return;
+  }
+
+  // Check if this transfer is already active (should ideally not happen)
+  if (activeSenders.has(transfer_room)) {
+    console.warn(`[FileSender] Transfer already active for room: ${transfer_room}. Ignoring new request.`);
+    return;
+  }
+
+  let fileStream: fs.ReadStream | null = null;
 
   try {
     // Join transfer room first
@@ -25,8 +54,12 @@ export async function handleFileRequest(
     }));
 
     // Read file
-    const fileStream = fs.createReadStream(file_path, { highWaterMark: CHUNK_SIZE });
+    fileStream = fs.createReadStream(file_path, { highWaterMark: CHUNK_SIZE });
     const fileStats = fs.statSync(file_path);
+
+    // Add to active senders map *before* starting the loop
+    activeSenders.set(transfer_room, { shouldCancel: false, stream: fileStream });
+    console.log(`[FileSender] Starting send for room: ${transfer_room}, file: ${file_name}`);
 
     // Send file transfer start message
     socket.send(JSON.stringify({
@@ -39,9 +72,17 @@ export async function handleFileRequest(
       }
     }));
 
-
     // Send file in chunks
     for await (const chunk of fileStream) {
+      const senderInfo = activeSenders.get(transfer_room);
+
+      // Check for cancellation signal before sending chunk
+      if (senderInfo?.shouldCancel) {
+        console.log(`[FileSender] Cancellation detected for room: ${transfer_room}. Stopping stream.`);
+        // Stream will be destroyed in the finally block
+        break; // Exit the loop
+      }
+
       // Wait for a small delay to prevent overwhelming the connection
       await new Promise(resolve => setTimeout(resolve, 10));
       
@@ -60,48 +101,57 @@ export async function handleFileRequest(
       }
     }
 
-    // Send completion message
-    socket.send(JSON.stringify({
-      message_type: 'file_transfer_complete',
-      file_name: file_name,
-      file_path: file_path,
-      requesting_device_id: requesting_device_id
-    }));
-
-    // Update task status
-    if (tasks && setTasks) {
-      const updatedTasks = tasks.map(task =>
-        task.file_name === file_name ? { ...task, status: 'complete' } : task
-      );
-      setTasks(updatedTasks);
-    }
-
-    // Leave transfer room after successful completion
-    if (transfer_room) {
-      setTimeout(() => {
-        
+    // Check if the loop was exited due to cancellation
+    const senderInfoAfterLoop = activeSenders.get(transfer_room);
+    if (senderInfoAfterLoop?.shouldCancel) {
+        console.log(`[FileSender] Transfer cancelled for room: ${transfer_room}. Skipping completion message.`);
+        // Optionally send a specific cancellation confirmation
+        // socket.send(JSON.stringify({ message_type: 'transfer_cancelled_by_sender', transfer_room }));
+    } else {
+        // Send completion message only if not cancelled
+        console.log(`[FileSender] Sending completion message for room: ${transfer_room}`);
         socket.send(JSON.stringify({
-          message_type: 'leave_transfer_room',
-          transfer_room: transfer_room,
-          timestamp: Date.now()
+          message_type: 'file_transfer_complete',
+          file_name: file_name,
+          file_path: file_path,
+          requesting_device_id: requesting_device_id,
+          transfer_room: transfer_room // Include transfer_room for context
         }));
-      }, 2000); // Give enough time for completion acknowledgment
+
+        // Update task status only if completed successfully
+        if (tasks && setTasks) {
+          const updatedTasks = tasks.map(task =>
+            task.file_name === file_name ? { ...task, status: 'complete' } : task
+          );
+          setTasks(updatedTasks);
+        }
     }
 
   } catch (error) {
-    console.error('❌ Error sending file:', error);
+    console.error(`❌ [FileSender] Error during file send for room ${transfer_room}:`, error);
+    // Optionally send error message back
     socket.send(JSON.stringify({
       message_type: 'file_transfer_error',
-      error: error instanceof Error ? error.message : 'Error sending file',
-      file_name: file_name
+      error: error instanceof Error ? error.message : 'Unknown error during file send',
+      file_name: file_name,
+      transfer_room: transfer_room
     }));
-
-    // Update task status to error
-    if (tasks && setTasks) {
-      const updatedTasks = tasks.map(task =>
-        task.file_name === file_name ? { ...task, status: 'error' } : task
-      );
-      setTasks(updatedTasks);
+  } finally {
+    console.log(`[FileSender] Cleaning up for room: ${transfer_room}`);
+    // Ensure stream is destroyed and entry is removed from map
+    if (fileStream) {
+      fileStream.destroy();
     }
+    activeSenders.delete(transfer_room);
+    console.log(`[FileSender] Removed sender entry for room: ${transfer_room}`);
+
+    // Leave transfer room after completion or cancellation
+    // It's important the sender also leaves the room
+    socket.send(JSON.stringify({
+      message_type: 'leave_transfer_room',
+      transfer_room: transfer_room,
+      timestamp: Date.now()
+    }));
+    console.log(`[FileSender] Sent leave_transfer_room for room: ${transfer_room}`);
   }
 } 

--- a/packages/core/src/websocket/files/file_transfer.ts
+++ b/packages/core/src/websocket/files/file_transfer.ts
@@ -1,6 +1,6 @@
 import os from 'os';
 import { get_device_id } from '../../device/get_device_id';
-import { addDownloadsInfo, DownloadInfo, getDownloadsInfo, clearDownloadsInfo, cleanupDownloadTracker } from '../../device/add_downloads_info';
+import { addDownloadsInfo, DownloadInfo } from '../../device/add_downloads_info';
 
 
 // Function to send a download request using the provided socket
@@ -196,7 +196,6 @@ export async function cancel_download_request(socket: WebSocket, username: strin
       transfer_room: downloadInfo.transfer_room,
     };
     socket.send(JSON.stringify(message));
-    console.log(`Sent cancel request for file: ${downloadInfo.filename} in room ${downloadInfo.transfer_room}`);
 
     // Note: This only sends the request. We might need logic here or elsewhere
     // to handle confirmation or update UI state immediately to 'cancelling'.

--- a/packages/core/src/websocket/files/file_transfer.ts
+++ b/packages/core/src/websocket/files/file_transfer.ts
@@ -166,4 +166,35 @@ export async function leaveTransferRoom(socket: WebSocket, transfer_room: string
   } catch (error) {
     socket.send(JSON.stringify({'error': 'Error leaving transfer room', 'details': error}));
   }
+}
+
+// Function to send a cancel download request
+export async function cancel_download_request(socket: WebSocket, username: string, filename: string) {
+  if (!socket || socket.readyState !== WebSocket.OPEN) {
+    console.error('WebSocket is not open for cancelling download.');
+    return;
+  }
+
+  try {
+    const requesting_device_id = await get_device_id(username);
+    const message = {
+      message_type: "cancel_download_request",
+      username: username,
+      filename: filename,
+      requesting_device_id: requesting_device_id,
+      // We might need transfer_room here if the backend requires it
+      // Ideally, the backend can associate filename + requesting_device_id with the active transfer
+    };
+    socket.send(JSON.stringify(message));
+    console.log(`Sent cancel request for file: ${filename}`);
+
+    // Note: This only sends the request. We might need logic here or elsewhere
+    // to handle confirmation or update UI state immediately to 'cancelling'.
+    // For now, rely on addDownloadsInfo being called separately.
+
+  } catch (error) {
+    console.error('Error sending cancel download request:', error);
+    // Optionally send an error message back via websocket if appropriate
+    // socket.send(JSON.stringify({ 'error': 'Failed to send cancel request', 'details': error }));
+  }
 } 

--- a/packages/core/src/websocket/files/file_transfer_handler.ts
+++ b/packages/core/src/websocket/files/file_transfer_handler.ts
@@ -73,7 +73,6 @@ export async function handleFileTransferMessage(event: MessageEvent<BinaryData |
         case 'transfer_room_joined':
           if (transfer_room) {
             activeTransferRooms.add(transfer_room);
-            console.log(`[TransferHandler] Joined room: ${transfer_room}`);
           }
           break;
 

--- a/packages/frontend/src/components/common/DownloadProgressButton/DownloadProgressButton.tsx
+++ b/packages/frontend/src/components/common/DownloadProgressButton/DownloadProgressButton.tsx
@@ -12,23 +12,19 @@ import {
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-// For the trigger button
+import ErrorIcon from '@mui/icons-material/Error';
+import { useAuth } from '../../../renderer/context/AuthContext';
+import { banbury } from '@banbury/core';
+import { addDownloadsInfo, DownloadInfo } from '@banbury/core/src/device/add_downloads_info';
 
 interface DownloadProgressProps {
-  downloads: {
-    filename: string;
-    fileType: string;
-    progress: number;
-    status: 'downloading' | 'completed' | 'failed' | 'skipped';
-    totalSize: number;
-    downloadedSize: number;
-    timeRemaining?: number;
-  }[];
+  downloads: DownloadInfo[];
 }
 
 export default function DownloadProgress({ downloads }: DownloadProgressProps) {
   const [selectedTab, setSelectedTab] = useState<'all' | 'completed' | 'skipped' | 'failed'>('all');
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+  const { username, websocket } = useAuth();
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     if (anchorEl) {
@@ -42,13 +38,34 @@ export default function DownloadProgress({ downloads }: DownloadProgressProps) {
     setAnchorEl(null);
   };
 
+  const handleCancelClick = async (downloadToCancel: DownloadInfo) => {
+    if (!websocket || websocket.readyState !== WebSocket.OPEN) {
+      console.error('Cannot cancel download: WebSocket is not open.');
+      return;
+    }
+    if (!username) {
+        console.error('Cannot cancel download: Username not found.');
+        return;
+    }
+
+    console.log(`Attempting to cancel download for: ${downloadToCancel.filename}`);
+    await banbury.files.cancel_download_request(websocket, username, downloadToCancel.filename);
+
+    addDownloadsInfo([
+      {
+        ...downloadToCancel,
+        status: 'failed',
+        progress: downloadToCancel.progress,
+        timeRemaining: undefined,
+      },
+    ]);
+  };
+
   const open = Boolean(anchorEl);
   const id = open ? 'progress-popover' : undefined;
 
-  // Show upload count badge if there are active uploads
   const activeDownloads = downloads.filter(download => download.status === 'downloading').length;
 
-  // Add this filtering logic before the return statement
   const filteredDownloads = downloads.filter(download => {
     if (selectedTab === 'all') return true;
     return download.status === selectedTab;
@@ -112,7 +129,6 @@ export default function DownloadProgress({ downloads }: DownloadProgressProps) {
         }}
       >
         <Box sx={{ p: 2 }}>
-          {/* Header */}
           <Box sx={{
             display: 'flex',
             justifyContent: 'space-between',
@@ -125,7 +141,6 @@ export default function DownloadProgress({ downloads }: DownloadProgressProps) {
             </IconButton>
           </Box>
 
-          {/* Tabs */}
           <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
             {['All downloads', 'Completed', 'Skipped', 'Failed'].map((tab) => (
               <Button
@@ -147,7 +162,6 @@ export default function DownloadProgress({ downloads }: DownloadProgressProps) {
             ))}
           </Stack>
 
-          {/* Upload List */}
           <Stack spacing={2}>
             {filteredDownloads.length === 0 ? (
               <Typography sx={{ color: 'rgba(255,255,255,0.7)', textAlign: 'center', py: 4 }}>
@@ -164,20 +178,23 @@ export default function DownloadProgress({ downloads }: DownloadProgressProps) {
                     p: 1
                   }}
                 >
-                  {/* Status Icon */}
                   {download.status === 'downloading' ? (
                     <CircularProgress size={24} />
-                  ) : (
+                  ) : download.status === 'completed' ? (
                     <CheckCircleIcon color="success" />
-                  )}
+                  ) : download.status === 'failed' || download.status === 'skipped' ? (
+                    <ErrorIcon color="error" />
+                  ) : null}
 
-                  {/* File Info */}
                   <Box sx={{ flex: 1 }}>
                     <Typography sx={{ color: 'white' }}>{download.filename}</Typography>
                     <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.7)' }}>
                       {download.status === 'downloading'
                         ? `Downloading ${(download.downloadedSize / (1024 * 1024)).toFixed(1)}mb / ${(download.totalSize / (1024 * 1024)).toFixed(1)}mb - ${download.timeRemaining}s left...`
-                        : `Downloaded to Files`
+                        : download.status === 'completed' ? `Downloaded to Files`
+                        : download.status === 'failed' ? 'Download failed'
+                        : download.status === 'skipped' ? 'Download skipped'
+                        : 'Status unknown'
                       }
                     </Typography>
                     {download.status === 'downloading' && (
@@ -189,7 +206,6 @@ export default function DownloadProgress({ downloads }: DownloadProgressProps) {
                     )}
                   </Box>
 
-                  {/* Action Button */}
                   {download.status === 'downloading' ? (
                     <Button
                       variant="contained"
@@ -197,6 +213,7 @@ export default function DownloadProgress({ downloads }: DownloadProgressProps) {
                       sx={{
                         fontSize: '12px',
                       }}
+                      onClick={() => handleCancelClick(download)}
                     >
                       Cancel
                     </Button>

--- a/packages/frontend/src/components/common/DownloadProgressButton/DownloadProgressButton.tsx
+++ b/packages/frontend/src/components/common/DownloadProgressButton/DownloadProgressButton.tsx
@@ -13,6 +13,7 @@ import {
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorIcon from '@mui/icons-material/Error';
+import WarningIcon from '@mui/icons-material/Warning';
 import { useAuth } from '../../../renderer/context/AuthContext';
 import { banbury } from '@banbury/core';
 import { addDownloadsInfo, DownloadInfo } from '@banbury/core/src/device/add_downloads_info';
@@ -181,8 +182,10 @@ export default function DownloadProgress({ downloads }: DownloadProgressProps) {
                     <CircularProgress size={24} />
                   ) : download.status === 'completed' ? (
                     <CheckCircleIcon color="success" />
-                  ) : download.status === 'failed' || download.status === 'skipped' ? (
+                  ) : download.status === 'failed' ? (
                     <ErrorIcon color="error" />
+                  ) : download.status === 'skipped' ? (
+                    <WarningIcon sx={{ color: 'warning.main' }} />
                   ) : null}
 
                   <Box sx={{ flex: 1 }}>

--- a/packages/frontend/src/components/common/DownloadProgressButton/DownloadProgressButton.tsx
+++ b/packages/frontend/src/components/common/DownloadProgressButton/DownloadProgressButton.tsx
@@ -48,7 +48,6 @@ export default function DownloadProgress({ downloads }: DownloadProgressProps) {
         return;
     }
 
-    console.log(`Attempting to cancel download for: ${downloadToCancel.filename}`);
     await banbury.files.cancel_download_request(websocket, username, downloadToCancel.filename);
 
     addDownloadsInfo([

--- a/packages/frontend/src/components/common/DownloadProgressButton/DownloadProgressButton.tsx
+++ b/packages/frontend/src/components/common/DownloadProgressButton/DownloadProgressButton.tsx
@@ -48,7 +48,7 @@ export default function DownloadProgress({ downloads }: DownloadProgressProps) {
         return;
     }
 
-    await banbury.files.cancel_download_request(websocket, username, downloadToCancel.filename);
+    await banbury.files.cancel_download_request(websocket, username, downloadToCancel);
 
     addDownloadsInfo([
       {


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Implements download cancellation functionality by adding a websocket message handler and connecting the Cancel button in the UI to this new functionality.

- Added `cancel_download_request` function in `websocket/files/file_transfer.ts` that sends a cancellation message to the server.
- Exported the cancellation function through `files/index.ts` to make it available in the public API.
- Implemented `handleCancelClick` in `DownloadProgressButton.tsx` that calls the cancellation function and optimistically updates the UI.
- Enhanced the download status display to show different messages and icons based on download status (completed, failed, skipped).

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

This PR fixes issue #376 by implementing the download cancellation functionality.

- Adds a `cancel_download_request` function to `@banbury/core/files` which sends a websocket message.
- Adds an `onClick` handler to the 'Cancel' button in `DownloadProgressButton.tsx`.
- The handler calls `cancel_download_request` and optimistically updates the UI to show the download as failed/cancelled.