### PR TITLE
more test fixes

### DIFF
--- a/packages/frontend/tests/e2e/004.devices.spec.ts
+++ b/packages/frontend/tests/e2e/004.devices.spec.ts
@@ -262,6 +262,9 @@ test.describe('Devices tests', () => {
     // Confirm that there is a message in the alert that says "Device deleted successfully"
     const alertMessage = window.locator('[data-testid="alert-success"]');
     await expect(alertMessage).toContainText('Device(s) deleted successfully', { timeout: 5000 });
+
+    // wait for the alert to disappear
+    await window.waitForSelector('[data-testid="alert-success"]', { state: 'hidden' });
   });
 
   test('handles empty devices state correctly', async () => {
@@ -368,6 +371,9 @@ test.describe('Devices tests', () => {
     // Confirm that there is a message in the alert that says "Device already exists"
     const alertMessage = window.locator('[data-testid="alert-error"]');
     await expect(alertMessage).toContainText('Device already exists', { timeout: 5000000 });
+
+    // wait for the alert to disappear
+    await window.waitForSelector('[data-testid="alert-error"]', { state: 'hidden' });
   });
 
   test('can edit a device', async () => {


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Adds wait conditions for alert messages to disappear in device management E2E tests to improve test reliability.

- Added a wait condition in `packages/frontend/tests/e2e/004.devices.spec.ts` for the success alert to disappear after deleting a device.
- Added a wait condition in `packages/frontend/tests/e2e/004.devices.spec.ts` for the error alert to disappear after attempting to add a device that already exists.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->